### PR TITLE
Fix double assign of sites.

### DIFF
--- a/test/geo-voronoi-test.js
+++ b/test/geo-voronoi-test.js
@@ -3,6 +3,8 @@ var path = require('path');
 var tape = require("tape");
 var geoVoronoi = require("../");
 
+var sites = [[0,0], [10,0], [0,10]];
+
 tape("geoVoronoi() returns a Diagram.", function(test) {
   test.equal(typeof geoVoronoi, 'object');
   test.equal(typeof geoVoronoi.geoVoronoi, 'function');
@@ -16,9 +18,6 @@ tape("geoVoronoi() returns a Diagram.", function(test) {
   test.equal(typeof geoVoronoi.geoVoronoi().triangles([]), 'object');
   test.end();
 });
-
-
-var sites = [[0,0], [10,0]];
 
 tape("geoVoronoi.polygons(sites) returns polygons.", function(test) {
   var u = geoVoronoi.geoVoronoi(sites).polygons()
@@ -50,8 +49,6 @@ tape("geoVoronoi.polygons([1 site]) returns a Sphere.", function(test) {
   test.equal(u.features[0].geometry.type, "Sphere");
   test.end();
 });
-
-var sites = [[0,0], [10,0], [0,10]];
 
 tape("geoVoronoi.links() returns urquhart.", function(test) {
   test.deepEqual(geoVoronoi.geoVoronoi().links(sites).features.map(function(d) { return d.properties.urquhart; }), [ false, true, true ]);


### PR DESCRIPTION
This is a common error.. and my PR can  be read interpreted as a readability improvement request rather than an bug report.

Looking at test/geo-voronoi-test.js

As the sites variable in scope is a file level variable...  plus  the fact that it is defined twice, it means it is  always overwritten before being used.

From looking at this in the debugger I can say this ...

A) It is ineffectually defined first as a 2-point array 
B) Redefined as a 3 point array 
C) Used in all test methods as a 3 point array. no matter the relative position on the test method.

The confusion is that 

1) sites is needlessly defined twice 
2) That the casual reader might assume the 2-point definition is actually being used in some tests.

Anyway a semi trivial issue .. I just want to make the code more readable.

