### PR TITLE
geo_urquhart() using Map as appropiate.

### DIFF
--- a/src/delaunay.js
+++ b/src/delaunay.js
@@ -358,12 +358,12 @@ function geo_mesh(polygons) {
 
 function geo_urquhart(edges, triangles) {
   return function(distances) {
-    const _lengths = {},
-      _urquhart = {};
+    const _lengths = new Map(),
+      _urquhart = new Map();
     edges.forEach((edge, i) => {
       const u = edge.join("-");
-      _lengths[u] = distances[i];
-      _urquhart[u] = true;
+      _lengths.set(u, distances[i]);
+      _urquhart.set(u, true);
     });
 
     triangles.forEach(tri => {
@@ -371,15 +371,15 @@ function geo_urquhart(edges, triangles) {
         remove = -1;
       for (var j = 0; j < 3; j++) {
         let u = extent([tri[j], tri[(j + 1) % 3]]).join("-");
-        if (_lengths[u] > l) {
-          l = _lengths[u];
+        if (_lengths.get(u) > l) {
+          l = _lengths.get(u);
           remove = u;
         }
       }
-      _urquhart[remove] = false;
+      _urquhart.set(remove,  false);
     });
 
-    return edges.map(edge => _urquhart[edge.join("-")]);
+    return edges.map(edge => _urquhart.get(edge.join("-")));
   };
 }
 


### PR DESCRIPTION
as a followup to #24 

I ran a global search for "={}" to see if there were anymore examples of a javascript  "Object" being used where a more appropriate data structure was available.

I found 2 examples 

geo_edges()
geo_urquhart()

The CS mantra I am invoking is "Choose the underlying data structure appropriately for the data flow in your design."

The has a subtle benefit that the runtime environment and JIT compiler now has more  semantic clues that may lead to more optimal performance.

For example occasionally we might be able to say that if the JIT can look ahead and see a change from a data structure with 5 elements to a data structure with 100 000 elements then it will view to memory storage speed trade-offs differently.

I appreciate that this is all a bit hand wavey, so I am open to criticism on that front. but it is still a change I would like to make.

In this PR I am only fixing geo_urqhart() because the fix I have geo_edges() I think has a backwards compatible breaking change and so that fix should be prepared and reviewed in isolation.

