### PR TITLE
package 'tape': Fix security dependabot alert.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "package-preamble": "0.1",
     "rollup": "0.49",
-    "tape": "4",
+    "tape": "5.3.1",
     "terser": "^3.8.2"
   }
 }


### PR DESCRIPTION
Just a one line maintaince patch

Dependabot is  generating this security alert against my mirror of this module.

https://github.com/martinfrances107/d3-geo-voronoi/security/dependabot/yarn.lock/path-parse/open

here is the reason we need to update the tape package .. one of its dependecies has this problem  :- 
[I can say ... locally the test look fine and my benchmark run as expected.]

CVE-2021-23343
moderate severity
Vulnerable versions: < 1.0.7
Patched version: 1.0.7
Affected versions of npm package path-parse are vulnerable to Regular Expression Denial of Service (ReDoS) via splitDeviceRe, splitTailRe, and splitPathRe regular expressions. ReDoS exhibits polynomial worst-case time complexity.