### PR TITLE
Added hemisphere test

### DIFF
--- a/test/geo-voronoi-test.js
+++ b/test/geo-voronoi-test.js
@@ -19,38 +19,36 @@ it("geoVoronoi() returns a Diagram.", () => {
 });
 
 it("geoVoronoi.polygons(sites) hemisphere test", () => {
-	const two_sites = [[-20, -20], [20, 20]];
-	const polygons = geoVoronoi.geoVoronoi(two_sites).polygons();
-	assert.deepStrictEqual(
-	  polygons.features[0].geometry,
-	  {
-		type: 'Polygon',
-		coordinates: [[
-		  [0, 0],
-		  [90, -43.21917889371418],
-		  [180, -0],
-		  [-90, 43.21917889371418],
-		  [0, 0]
-		]]
-	  }
-	);
+        const two_sites = [[-20, -20], [20, 20]];
+        const polygons = geoVoronoi.geoVoronoi(two_sites).polygons();
+        assert.deepStrictEqual(
+          polygons.features[0].geometry,
+          {
+            type: 'Polygon',
+            coordinates: [[
+              [0, 0],
+              [90, -43.21917889371418],
+              [180, -0],
+              [-90, 43.21917889371418],
+              [0, 0]
+            ]]
+          }
+        );
 
-	assert.deepStrictEqual(
-	  polygons.features[1].geometry,
-	  {
-		type: 'Polygon',
-		coordinates: [[
-		  [-90, 43.21917889371418],
-		  [180, -0],
-		  [90, -43.21917889371418],
-		  [0, 0],
-		  [-90, 43.21917889371418]
-
-		]]
-	  }
-	);
-
-  });
+        assert.deepStrictEqual(
+          polygons.features[1].geometry,
+          {
+            type: 'Polygon',
+            coordinates: [[
+              [-90, 43.21917889371418],
+              [180, -0],
+              [90, -43.21917889371418],
+              [0, 0],
+              [-90, 43.21917889371418]
+             ]]
+           }
+         );
+ });
 
 it("geoVoronoi.polygons(sites) returns polygons.", () => {
   const u = geoVoronoi.geoVoronoi(sites).polygons()

--- a/test/geo-voronoi-test.js
+++ b/test/geo-voronoi-test.js
@@ -18,6 +18,40 @@ it("geoVoronoi() returns a Diagram.", () => {
   assert.strictEqual(typeof geoVoronoi.geoVoronoi().triangles([]), 'object');
 });
 
+it("geoVoronoi.polygons(sites) hemisphere test", () => {
+	const two_sites = [[-20, -20], [20, 20]];
+	const polygons = geoVoronoi.geoVoronoi(two_sites).polygons();
+	assert.deepStrictEqual(
+	  polygons.features[0].geometry,
+	  {
+		type: 'Polygon',
+		coordinates: [[
+		  [0, 0],
+		  [90, -43.21917889371418],
+		  [180, -0],
+		  [-90, 43.21917889371418],
+		  [0, 0]
+		]]
+	  }
+	);
+
+	assert.deepStrictEqual(
+	  polygons.features[1].geometry,
+	  {
+		type: 'Polygon',
+		coordinates: [[
+		  [-90, 43.21917889371418],
+		  [180, -0],
+		  [90, -43.21917889371418],
+		  [0, 0],
+		  [-90, 43.21917889371418]
+
+		]]
+	  }
+	);
+
+  });
+
 it("geoVoronoi.polygons(sites) returns polygons.", () => {
   const u = geoVoronoi.geoVoronoi(sites).polygons()
             .features[0].geometry.coordinates[0][0],


### PR DESCRIPTION
The code below labelled

// two hemispheres

 is  specialisation logic that is invoked  only when  two sites are input.

This is not covered by any existing test.

I had to develop this test to expose a bug in my port of this module to rust.
so from a certain limited perspective this is a upstream push..



to critise my own work floating point number are hard-coded into the test
.. depending on what people think I could refactor and compare the individual floats 
to within 1e-6?

**src/delaunay.rs**
```
 if (triangles.length === 0) {
    if (points.length < 2) return { polygons, centers };
    if (points.length === 2) {
      // two hemispheres
      const a = cartesian(points[0]),
        b = cartesian(points[1]),
        m = normalize(cartesianAdd(a, b)),
        d = normalize(cross(a, b)),
        c = cross(m, d);
      const poly = [
        m,
        cross(m, c),
        cross(cross(m, c), c),
        cross(cross(cross(m, c), c), c)
      ]
        .map(spherical)
        .map(supplement);
      return (
        polygons.push(poly),
        polygons.push(poly.slice().reverse()),
        { polygons, centers }
      );
    }
  }
```
