### PR TITLE
Minor: Benchmark now uses d3@v7.

### DIFF
--- a/benchmark/sphereCanvas.html
+++ b/benchmark/sphereCanvas.html
@@ -32,7 +32,7 @@
     <h2> Suggestion: </h2>
     <p> Enable the browsers FPS meter. </p>
 
-    <script src="https://unpkg.com/d3@6"></script>
+    <script src="https://unpkg.com/d3@7"></script>
     <script src="../dist/d3-geo-voronoi.min.js"></script>
 
     <script>


### PR DESCRIPTION
The benchmark was developed when d3v6 was the lastest

This migration has no perceptable change in performance, but I think it is safer to always compare with the lastest version of d3.